### PR TITLE
show Hz at top level, avg iter time for children

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,11 +274,24 @@ impl ProfileNode {
                               .as_ref()
                               .map(|p| p.total_time.get())
                               .unwrap_or(self.total_time.get()) as f64;
-        println!("{} - {} ({:.1}%)",
-            self.name,
-            Nanoseconds(self.total_time.get()),
-            100.0 * (self.total_time.get() as f64 / parent_time)
-        );
+        let percent = 100.0 * (self.total_time.get() as f64 / parent_time);
+        if percent.is_infinite() {
+            println!("{name} - {calls} * {each} = {total} @ {hz:.1}hz",
+                name  = self.name,
+                calls = self.calls.get(),
+                each = Nanoseconds((self.total_time.get() as f64 / self.calls.get() as f64) as u64),
+                total = Nanoseconds(self.total_time.get()),
+                hz = self.calls.get() as f64 / self.total_time.get() as f64 * 1e9f64
+            );
+        } else {
+            println!("{name} - {calls} * {each} = {total} ({percent:.1}%)",
+                name  = self.name,
+                calls = self.calls.get(),
+                each = Nanoseconds((self.total_time.get() as f64 / self.calls.get() as f64) as u64),
+                total = Nanoseconds(self.total_time.get()),
+                percent = percent
+            );
+        }
         for c in &*self.children.borrow() {
             c.print(indent+2);
         }


### PR DESCRIPTION
I'm timing tight loops and wanted individual timings as well as Hz (which only makes sense for the entire loop, not parts of it). This patch reworks the format string in `ProfileNode::print` to show the frequency instead of percentage for top-level nodes (detected by checking if it was going to print "inf%") and the average time-per-iteration for all nodes.

Sample output:

```
Timing information for structure:
  step - 7 * 560.5ms = 3.9s @ 1.8hz
    depth - 7 * 560.5ms = 3.9s (100.0%)
      readFrame - 7 * 7.8ms = 54.6ms (1.4%)
      frame.data() - 7 * 89ns = 628ns (0.0%)
      PNGEncoder - 7 * 25.3ms = 176.9ms (4.5%)
      tx.send - 7 * 2.3ms = 15.9ms (0.4%)
```
